### PR TITLE
listStatus must have empty body

### DIFF
--- a/docusign_esign/apis/envelopes_api.py
+++ b/docusign_esign/apis/envelopes_api.py
@@ -8772,7 +8772,7 @@ class EnvelopesApi(object):
         form_params = []
         local_var_files = {}
 
-        body_params = None
+        body_params = {}
         if 'envelope_ids_request' in params:
             body_params = params['envelope_ids_request']
         # HTTP header `Accept`

--- a/docusign_esign/client/api_response.py
+++ b/docusign_esign/client/api_response.py
@@ -134,7 +134,7 @@ class RESTClientObject(object):
                     url += '?' + urlencode(query_params)
                 if re.search('json', headers['Content-Type'], re.IGNORECASE):
                     request_body = None
-                    if body:
+                    if body is not None:
                         request_body = json.dumps(body)
                     r = self.pool_manager.request(method, url,
                                                   body=request_body,


### PR DESCRIPTION
From the documentation for the listStatus for envelopes:
_It is an error omit the request body altogether. The request
body must be at least {}_.  Currently `None` is being rather
than an empty body.

I need someone with some more expertise who can confirm this
change made in this way is safe and/or if it should be expanded
to other methods as well that have the same problem.
