### PR TITLE
Update PyJWT to 2.3.0

### DIFF
--- a/docusign_esign/client/api_client.py
+++ b/docusign_esign/client/api_client.py
@@ -115,8 +115,8 @@ class ApiClient(object):
                    _request_timeout=None):
         """
         :param _preload_content: if False, the urllib3.HTTPResponse object will be returned without
-                                 reading/decoding response data. Default is True. 
-        :return: 
+                                 reading/decoding response data. Default is True.
+        :return:
         """
 
         # header parameters
@@ -686,7 +686,7 @@ class ApiClient(object):
         later = now + (expires_in * 1)
         claim = {"iss": client_id, "sub": user_id, "aud": oauth_host_name, "iat": now, "exp": later,
                  "scope": " ".join(scopes)}
-        token = jwt.encode(payload=claim, key=private_key_bytes, algorithm='RS256').decode("utf-8")
+        token = jwt.encode(payload=claim, key=private_key_bytes, algorithm='RS256')
         response = self.request("POST", "https://" + oauth_host_name + "/oauth/token",
                                 headers=self.sanitize_for_serialization(
                                     {"Content-Type": "application/x-www-form-urlencoded"}),
@@ -818,8 +818,8 @@ class ApiClient(object):
     def set_access_token(self, token_obj):
         """
 
-        :param token_obj: 
-        :return: 
+        :param token_obj:
+        :return:
         """
         self.default_headers['Authorization'] = token_obj.access_token
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ six >= 1.8.0
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.15
-PyJWT>=1.7.1,<2
+PyJWT>=2
 cryptography>=2.5
 nose>=1.3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ six >= 1.8.0
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.15
-PyJWT>=2
+PyJWT==2.3.0
 cryptography>=2.5
 nose>=1.3.7

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@
 """
 
 
-from setuptools import setup, find_packages, Command, os  # noqa: H301	
+from setuptools import setup, find_packages, Command, os  # noqa: H301
 
 NAME = "docusign-esign"
 VERSION = "3.14.0rc1"
@@ -22,7 +22,7 @@ VERSION = "3.14.0rc1"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["urllib3 >= 1.15", "six >= 1.8.0", "certifi >= 14.05.14", "python-dateutil >= 2.5.3", "setuptools >= 21.0.0", "PyJWT>=1.7.1,<2", "cryptography>=2.5", "nose>=1.3.7"]
+REQUIRES = ["urllib3 >= 1.15", "six >= 1.8.0", "certifi >= 14.05.14", "python-dateutil >= 2.5.3", "setuptools >= 21.0.0", "PyJWT==2.3.0", "cryptography>=2.5", "nose>=1.3.7"]
 
 class CleanCommand(Command):
     """Custom clean command to tidy up the project root."""
@@ -37,7 +37,7 @@ class CleanCommand(Command):
 this_directory = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
-    
+
 
 setup(
     name=NAME,


### PR DESCRIPTION
This way, we can use this client with the latest version of Django Rest Framework