### PR TITLE
Removes PyJWT Max Version constraint from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 from setuptools import setup, find_packages, Command, os  # noqa: H301	
 
 NAME = "docusign-esign"
-VERSION = "3.18.0"
+VERSION = "3.18.1"
 # To install the library, run the following
 #
 # python setup.py install
@@ -22,7 +22,16 @@ VERSION = "3.18.0"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["urllib3 >= 1.15", "six >= 1.8.0", "certifi >= 14.05.14", "python-dateutil >= 2.5.3", "setuptools >= 21.0.0", "PyJWT>=1.7.1,<2", "cryptography>=2.5", "nose>=1.3.7"]
+REQUIRES = [
+    "urllib3 >= 1.15",
+    "six >= 1.8.0",
+    "certifi >= 14.05.14",
+    "python-dateutil >= 2.5.3",
+    "setuptools >= 21.0.0",
+    "PyJWT>=1.7.1",
+    "cryptography>=2.5",
+    "nose>=1.3.7"
+]
 
 class CleanCommand(Command):
     """Custom clean command to tidy up the project root."""


### PR DESCRIPTION
Removes PyJWT Max Version constraint from `setup.py`.

The dependency list from setup.py is now exactly the same from `requirements.txt`
