### PR TITLE
Fix setting the Authorization header in `set_access_token`

### DIFF
--- a/docusign_esign/client/api_client.py
+++ b/docusign_esign/client/api_client.py
@@ -818,10 +818,10 @@ class ApiClient(object):
     def set_access_token(self, token_obj):
         """
 
-        :param token_obj: 
-        :return: 
+        :param token_obj:
+        :return:
         """
-        self.default_headers['Authorization'] = token_obj.access_token
+        self.default_headers['Authorization'] = 'Bearer %s' % (token_obj.access_token)
 
     def get_authorization_uri(self, client_id, scopes, redirect_uri, response_type, state=None):
         """


### PR DESCRIPTION
In `client.api_client`, there is a method named `set_access_token`. This method takes an access token to set in the HTTP `Authorization` header that is sent to the Docusign API.

In integrating the Docusign API and using this SDK, specifically using the Authorization Code Grant authentication method, it was discovered that this method is incorrectly setting the `Authorization` header. It is simply setting the access token as the whole header value, rather than using the documented form of `"Bearer <access_token>"`.

This PR patches the method to add the word `Bearer`, bringing the method up to specification in the documentation.

I could not find any tests to run that where this method is called, but if there are any, I'll gladly run them and fix them as needed.

---
Documentation showing the use of `Bearer`
https://developers.docusign.com/platform/auth/authcode/authcode-get-token/