### PR TITLE
Exclude tests directory from being packaged

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     url="",
     keywords=["Swagger", "DocuSign REST API"],
     install_requires=REQUIRES,
-    packages=find_packages(),
+    packages=find_packages(exclude=["test"]),
     include_package_data=True,
     cmdclass={
         'clean': CleanCommand,


### PR DESCRIPTION
The tests directory was being packaged and installed with the library.

You can verify it by installing directly using `pip install docusign-esign`. It'll install the 'test' directory in site-packages.

This PR fixes that.