### PR TITLE
Version 3.26.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 See [DocuSign Support Center](https://support.docusign.com/en/releasenotes/) for Product Release Notes.
 
+## [v3.26.0] - eSignature API v2.1-23.4.02.00 - 2024-04-30
+### Changed
+- Revised the logic to determine the `oauth_host_name` based on the `base_path`.
+- Adjusted the minimum required `PyJWT` package version to `2.0.0`.
+- Added support for version v2.1-23.4.02.00 of the DocuSign ESignature API.
+- Updated the SDK release version.
+
 ## [v3.26.0rc1] - eSignature API v2.1-23.4.02.00 - 2024-03-12
 ### Changed
 - Added support for version v2.1-23.4.02.00 of the DocuSign ESignature API.

--- a/docusign_esign/client/configuration.py
+++ b/docusign_esign/client/configuration.py
@@ -119,9 +119,9 @@ class Configuration(object):
         python_version = platform.python_version()
 
         if six.PY3:
-            self.user_agent = "Swagger-Codegen/v2.1/3.26.0rc1/python3/" + f"{python_version}"
+            self.user_agent = "Swagger-Codegen/v2.1/3.26.0/python3/" + f"{python_version}"
         else:
-            self.user_agent = "Swagger-Codegen/v2.1/3.26.0rc1/python2/" + f"{python_version}"
+            self.user_agent = "Swagger-Codegen/v2.1/3.26.0/python2/" + f"{python_version}"
 
 
     @classmethod
@@ -277,5 +277,5 @@ class Configuration(object):
                "OS: {env}\n"\
                "Python Version: {pyversion}\n"\
                "Version of the API: v2.1\n"\
-               "SDK Package Version: 3.26.0rc1".\
+               "SDK Package Version: 3.26.0".\
                format(env=sys.platform, pyversion=sys.version)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 from setuptools import setup, find_packages, Command, os  # noqa: H301	
 
 NAME = "docusign-esign"
-VERSION = "3.26.0rc1"
+VERSION = "3.26.0"
 # To install the library, run the following
 #
 # python setup.py install


### PR DESCRIPTION
### Changed
- Revised the logic to determine the `oauth_host_name` based on the `base_path`.
- Adjusted the minimum required `PyJWT` package version to `2.0.0`.
- Added support for version v2.1-23.4.02.00 of the DocuSign ESignature API.
- Updated the SDK release version.
